### PR TITLE
fix: linter and violations, need to restore lazy views

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,6 +8,7 @@ import {
 import type { LinksFunction } from "@remix-run/node";
 
 import "./tailwind.css";
+import { useEffect } from "react";
 
 export const links: LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -23,6 +24,17 @@ export const links: LinksFunction = () => [
 ];
 
 export function Layout({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    import('react-scan').then(({ scan }) => {
+      scan({
+        includeChildren: true,
+        log: true,
+        report: true,
+      });
+    });
+  }, []);
   return (
     <html lang="en">
       <head>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -3,27 +3,36 @@ import { Link } from "@remix-run/react";
 
 export const meta: MetaFunction = () => {
   return [
-    { title: "MobX Demo" },
-    { name: "description", content: "MobX with Remix demo" },
+    { title: "MobX State Tree Demo" },
+    { name: "description", content: "MobX State Tree Demo" },
   ];
 };
 
 export default function Index() {
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="max-w-2xl mx-auto p-8 space-y-8 text-center">
-        <h1 className="text-3xl font-bold mb-8">MobX State Management Demo</h1>
-        
-        <div className="space-y-6">
-          <div className="p-6 border rounded-lg hover:shadow-lg transition-shadow">
-            <Link to="/hook" className="block space-y-2">
-              <h2 className="text-xl font-semibold text-blue-600">useObservable Hook</h2>
+    <div className="bg-white min-h-screen p-8">
+      <h1 className="text-4xl font-bold text-gray-800 mb-8">MobX State Tree Demo</h1>
+      <div className="space-y-6">
+        <div className="p-6 border rounded-lg shadow-sm">
+          <h2 className="text-2xl font-semibold text-gray-800 mb-4">Choose your implementation:</h2>
+          <div className="space-y-4">
+            <Link 
+              to="/observer" 
+              className="block p-4 bg-green-50 hover:bg-green-100 rounded-md border border-green-200 text-green-700"
+            >
+              👀 Observer HOC Implementation
             </Link>
-          </div>
-
-          <div className="p-6 border rounded-lg hover:shadow-lg transition-shadow">
-            <Link to="/observer" className="block space-y-2">
-              <h2 className="text-xl font-semibold text-blue-600">Observer HOC</h2>
+            <Link 
+              to="/hook" 
+              className="block p-4 bg-purple-50 hover:bg-purple-100 rounded-md border border-purple-200 text-purple-700"
+            >
+              🪝 Hook Implementation
+            </Link>
+            <Link 
+              to="/state" 
+              className="block p-4 bg-blue-50 hover:bg-blue-100 rounded-md border border-blue-200 text-blue-700"
+            >
+              ⚛️ React State Implementation
             </Link>
           </div>
         </div>

--- a/app/routes/hook.tsx
+++ b/app/routes/hook.tsx
@@ -12,7 +12,7 @@ export const meta: MetaFunction = () => {
 export default function HookPage() {
   const {
     count,
-    submodel: { title, allCaps, lowercase },
+    submodel: { title, allCaps},
   } = useObservable(store);
 
   console.log("Rendering")
@@ -20,12 +20,12 @@ export default function HookPage() {
   return (
     <div className="App">
       <h1>This page uses a hook for observing properties</h1>
-      <p>Open up React DevTools and you'll see that the `HookPage` component is properly memoized with React Compiler</p>
+      <p>Open up React DevTools and you&apos;ll see that the `HookPage` component is properly memoized with React Compiler</p>
       <p>
         {count}: {title}
       </p>
       <p>This is a computed view that capitalizes the title: {allCaps}</p>
-      <p>This is a lazily evaluated view that converts the title to lowercase: {lowercase()}</p>
+      {/* <p>This is a lazily evaluated view that converts the title to lowercase: {lowercase()}</p> */}
       <div className="flex flex-wrap gap-2">
         <button 
           onClick={() => store.increment()} 

--- a/app/routes/hook.tsx
+++ b/app/routes/hook.tsx
@@ -18,13 +18,13 @@ export default function HookPage() {
   console.log("Rendering")
   
   return (
-    <div className="App">
-      <h1>This page uses a hook for observing properties</h1>
-      <p>Open up React DevTools and you&apos;ll see that the `HookPage` component is properly memoized with React Compiler</p>
-      <p>
+    <div className="App bg-white p-8 min-h-screen">
+      <h1 className="text-3xl font-bold text-purple-600 mb-4">🪝 Using useObservable Hook 🪝</h1>
+      <p className="text-gray-800">Open up React DevTools and you&apos;ll see that the `HookPage` component is properly memoized with React Compiler</p>
+      <p className="text-gray-800 my-2">
         {count}: {title}
       </p>
-      <p>This is a computed view that capitalizes the title: {allCaps}</p>
+      <p className="text-gray-800 my-2">This is a computed view that capitalizes the title: {allCaps}</p>
       {/* <p>This is a lazily evaluated view that converts the title to lowercase: {lowercase()}</p> */}
       <div className="flex flex-wrap gap-2">
         <button 

--- a/app/routes/observer.tsx
+++ b/app/routes/observer.tsx
@@ -18,14 +18,13 @@ export default observer(function ObserverPage() {
   console.log("Rendering")
 
   return (
-    <div className="App">
-      <h1>This page uses an observer HOC</h1>
-      <p>Open up React DevTools and you&apos;ll see that the `ObserverPage` component is not memoized with React Compiler</p>
-      <p>
+    <div className="App bg-white p-8 min-h-screen">
+      <h1 className="text-3xl font-bold text-green-600 mb-4">👀 Using MobX Observer HOC 👀</h1>
+      <p className="text-gray-800">Open up React DevTools and you&apos;ll see that the `ObserverPage` component is not memoized with React Compiler</p>
+      <p className="text-gray-800 my-2">
         {count}: {title}
       </p>
-      <p>This is a computed view that capitalizes the title: {allCaps}</p>
-      {/* <p>This is a lazily evaluated view that converts the title to lowercase: {lowercase()}</p>  */}
+      <p className="text-gray-800 my-2">This is a computed view that capitalizes the title: {allCaps}</p>
       <div className="flex flex-wrap gap-2">
         <button 
           onClick={() => store.increment()} 

--- a/app/routes/observer.tsx
+++ b/app/routes/observer.tsx
@@ -12,7 +12,7 @@ export const meta: MetaFunction = () => {
 export default observer(function ObserverPage() {
   const {
     count,
-    submodel: { title, allCaps, lowercase },
+    submodel: { title, allCaps },
   } = store;
 
   console.log("Rendering")
@@ -20,12 +20,12 @@ export default observer(function ObserverPage() {
   return (
     <div className="App">
       <h1>This page uses an observer HOC</h1>
-      <p>Open up React DevTools and you'll see that the `ObserverPage` component is not memoized with React Compiler</p>
+      <p>Open up React DevTools and you&apos;ll see that the `ObserverPage` component is not memoized with React Compiler</p>
       <p>
         {count}: {title}
       </p>
       <p>This is a computed view that capitalizes the title: {allCaps}</p>
-      <p>This is a lazily evaluated view that converts the title to lowercase: {lowercase()}</p> 
+      {/* <p>This is a lazily evaluated view that converts the title to lowercase: {lowercase()}</p>  */}
       <div className="flex flex-wrap gap-2">
         <button 
           onClick={() => store.increment()} 

--- a/app/routes/state.tsx
+++ b/app/routes/state.tsx
@@ -1,0 +1,81 @@
+import type { MetaFunction } from "@remix-run/node";
+import { useState, useMemo } from "react";
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "React State" },
+    { name: "description", content: "React State Management" },
+  ];
+};
+
+export default function StatePage() {
+  const [count, setCount] = useState(0);
+  const [title, setTitle] = useState("Hello World");
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [shouldNotBeObserved, setShouldNotBeObserved] = useState("Do not render here");
+
+  // Equivalent to MST computed view
+  const allCaps = useMemo(() => title.toUpperCase(), [title]);
+
+  console.log("Rendering");
+
+  const increment = () => {
+    console.log("Incrementing count - should render");
+    setCount(prev => prev + 1);
+  };
+
+  const decrement = () => {
+    console.log("Decrementing count - should render");
+    setCount(prev => prev - 1);
+  };
+
+  const changeNonObservedProperty = () => {
+    console.log("Changing ignored property - should not render");
+    setShouldNotBeObserved(Math.random().toString());
+  };
+
+  const randomizeTitle = () => {
+    console.log("Randomizing title - should render");
+    const randomString = Array.from({ length: 8 }, () =>
+      "Hello World".charAt(Math.random() * 10)
+    ).join("");
+    setTitle(randomString);
+  };
+
+  return (
+    <div className="App bg-white p-8 min-h-screen">
+      <h1 className="text-3xl font-bold text-blue-600 mb-4">⚛️ Using React useState ⚛️</h1>
+      <p className="text-gray-800">Open up React DevTools and you&apos;ll see this component in the tree</p>
+      <p className="text-gray-800 my-2">
+        {count}: {title}
+      </p>
+      <p className="text-gray-800 my-2">This is a memoized value that capitalizes the title: {allCaps}</p>
+      <div className="flex flex-wrap gap-2">
+        <button 
+          onClick={increment} 
+          className="px-4 py-2 text-white font-semibold rounded-md bg-blue-500 hover:bg-blue-600 transition-colors"
+        >
+          +
+        </button>
+        <button 
+          onClick={decrement} 
+          className="px-4 py-2 text-white font-semibold rounded-md bg-red-500 hover:bg-red-600 transition-colors"
+        >
+          -
+        </button>
+        <button
+          onClick={changeNonObservedProperty}
+          className="px-4 py-2 text-white font-semibold rounded-md bg-purple-500 hover:bg-purple-600 transition-colors"
+        >
+          We do not observe the property this changes
+        </button>
+        <button
+          onClick={randomizeTitle}
+          className="px-4 py-2 text-white font-semibold rounded-md bg-green-500 hover:bg-green-600 transition-colors"
+        >
+          Randomize string
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.2.0",
         "react-compiler-runtime": "^19.0.0-beta-a7bf2bd-20241110",
         "react-dom": "^18.2.0",
+        "react-scan": "^0.0.26",
         "vite-plugin-babel": "^1.2.0"
       },
       "devDependencies": {
@@ -565,6 +566,27 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.3.5.tgz",
+      "integrity": "sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.8.2.tgz",
+      "integrity": "sha512-6b9Ab2UiZwJYA9iMyboYyW9yJvAO9V753ZhS+DHKEjZRKAxPPOb7MXXu84lsPFG+vZt6FRFniZ8rXi+zCIw4yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "0.3.5",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@emotion/hash": {
@@ -6616,7 +6638,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8099,7 +8120,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8785,6 +8805,50 @@
         "pathe": "^1.1.2"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -9343,6 +9407,22 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-scan": {
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/react-scan/-/react-scan-0.0.26.tgz",
+      "integrity": "sha512-LpVrcNCR1dNi+tcZKEsRx3aqKV6gfirgR4QbPz90fqkMgTtEqx48/y7VK/YXH0VLT6cGHue+Pxosbg+8QWcr4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "^0.3.5",
+        "@clack/prompts": "^0.8.2",
+        "kleur": "^4.1.5",
+        "mri": "^1.2.0",
+        "playwright": "^1.49.0"
+      },
+      "bin": {
+        "react-scan": "bin/cli.js"
       }
     },
     "node_modules/read-cache": {
@@ -9991,6 +10071,12 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^18.2.0",
     "react-compiler-runtime": "^19.0.0-beta-a7bf2bd-20241110",
     "react-dom": "^18.2.0",
+    "react-scan": "^0.0.26",
     "vite-plugin-babel": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In https://github.com/coolsoftwaretyler/react-compiler-demo-with-mobx-state-tree/issues/2, turns out I had the Rules of Hooks linter misconfigured. This PR fixes that, and re-writes the hook to actually follow the rules.

The compiler is still showing that it's working in React devtools, and the component renders as I expect.

This broke lazy-evaluated views, so I'll have to figure that out later as well.